### PR TITLE
aocdata: trim trailing newlines from inputs and answers.

### DIFF
--- a/aocdata/aocdata.go
+++ b/aocdata/aocdata.go
@@ -5,27 +5,30 @@ package aocdata
 import (
 	"embed"
 	"fmt"
+	"strings"
 )
 
 //go:embed *_input *_output
 var data embed.FS
 
 // Input returns the puzzle input for the given year and day. If no input was
-// found, it returns false.
+// found, it returns false. The input, if any, is returned with any trailing
+// newlines removed.
 func Input(year int, day int) (string, bool) {
 	input, err := data.ReadFile(fmt.Sprintf("year%d_day%02d_input", year, day))
 	if err != nil {
 		return "", false
 	}
-	return string(input), true
+	return strings.TrimRight(string(input), "\n"), true
 }
 
 // Answer returns the known answer for the given year, day, and part. If no
-// answer was found, it returns false.
+// answer was found, it returns false. The answer, if any, is returned with any
+// trailing newlines removed.
 func Answer(year int, day int, part int) (string, bool) {
 	answer, err := data.ReadFile(fmt.Sprintf("year%d_day%02d_part%d_output", year, day, part))
 	if err != nil {
 		return "", false
 	}
-	return string(answer), true
+	return strings.TrimRight(string(answer), "\n"), true
 }

--- a/aocdata/aocdata_test.go
+++ b/aocdata/aocdata_test.go
@@ -1,6 +1,9 @@
 package aocdata
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestInput(t *testing.T) {
 	// There should be data available for all existing problems. This test will
@@ -16,6 +19,9 @@ func TestInput(t *testing.T) {
 			if input == "" {
 				t.Errorf(`Input(%d, %d) input = ""; want non-empty`, year, day)
 				continue
+			}
+			if strings.TrimSpace(input) != input {
+				t.Errorf(`Input(%d, %d) input has trailing newlines: %q`, year, day, input)
 			}
 		}
 	}
@@ -34,8 +40,11 @@ func TestAnswer(t *testing.T) {
 					continue
 				}
 				if answer == "" {
-					t.Errorf(`Answer(%d, %d, %d) input = ""; want non-empty`, year, day, part)
+					t.Errorf(`Answer(%d, %d, %d) answer = ""; want non-empty`, year, day, part)
 					continue
+				}
+				if strings.HasSuffix(answer, "\n") {
+					t.Errorf(`Answer(%d, %d, %d) answer has trailing newlines: %q`, year, day, part, answer)
 				}
 			}
 		}


### PR DESCRIPTION
It makes sense to store the raw files with trailing newlines removed as that seems to be the convention among editors. However, for most solutions it becomes annoying to have to remember to trim the newlines everytime. This is a compromise.