### PR TITLE
year2015/day02: add solution.

### DIFF
--- a/year2015/day02/day02.go
+++ b/year2015/day02/day02.go
@@ -1,0 +1,50 @@
+package day02
+
+import (
+	"fmt"
+
+	"go.saser.se/adventofgo/striter"
+)
+
+func min(i int, is ...int) int {
+	r := i
+	for _, ii := range is {
+		if ii < r {
+			r = ii
+		}
+	}
+	return r
+}
+
+func wrappingPaper(l, w, h int) int {
+	return 2*l*w + 2*w*h + 2*h*l + min(l*w, w*h, l*h)
+}
+
+func ribbon(l, w, h int) int {
+	return l*w*h + min(2*(l+w), 2*(w+h), 2*(l+h))
+}
+
+func solve(input string, part int) (string, error) {
+	sum := 0
+	lines := striter.OverLines(input)
+	for line, ok := lines.Next(); ok; line, ok = lines.Next() {
+		var l, w, h int
+		if _, err := fmt.Sscanf(line, "%dx%dx%d", &l, &w, &h); err != nil {
+			return "", fmt.Errorf("parse line %q: %v", line, err)
+		}
+		if part == 1 {
+			sum += wrappingPaper(l, w, h)
+		} else {
+			sum += ribbon(l, w, h)
+		}
+	}
+	return fmt.Sprint(sum), nil
+}
+
+func Part1(input string) (string, error) {
+	return solve(input, 1)
+}
+
+func Part2(input string) (string, error) {
+	return solve(input, 2)
+}

--- a/year2015/day02/day02_test.go
+++ b/year2015/day02/day02_test.go
@@ -1,0 +1,57 @@
+package day02
+
+import (
+	"testing"
+
+	"go.saser.se/adventofgo/aoctest"
+)
+
+func TestPart1(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "2x3x4", want: "58"},
+		{input: "1x1x10", want: "43"},
+	} {
+		got, err := Part1(test.input)
+		if err != nil {
+			t.Errorf("Part1(%q) err = %v", test.input, err)
+			continue
+		}
+		if got != test.want {
+			t.Errorf("Part1(%q) = %q; want %q", test.input, got, test.want)
+			continue
+		}
+	}
+	aoctest.Test(t, 2015, 2, 1, Part1)
+}
+
+func TestPart2(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "2x3x4", want: "34"},
+		{input: "1x1x10", want: "14"},
+	} {
+		got, err := Part2(test.input)
+		if err != nil {
+			t.Errorf("Part2(%q) err = %v", test.input, err)
+			continue
+		}
+		if got != test.want {
+			t.Errorf("Part2(%q) = %q; want %q", test.input, got, test.want)
+			continue
+		}
+	}
+	aoctest.Test(t, 2015, 2, 2, Part2)
+}
+
+func BenchmarkPart1(b *testing.B) {
+	aoctest.Benchmark(b, 2015, 2, 1, Part1)
+}
+
+func BenchmarkPart2(b *testing.B) {
+	aoctest.Benchmark(b, 2015, 2, 2, Part2)
+}


### PR DESCRIPTION
I played around with swapping between `strings.Split` and `striter.OverLines` and it turns out that the latter actually is a bit faster. Not much, but a bit.