### PR TITLE
go.mod: bump Go version from 1.21 to 1.23.3.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.saser.se/adventofgo
 
-go 1.21
+go 1.23.3
 
 require (
 	github.com/golang/glog v1.2.0


### PR DESCRIPTION
There are lots of goodies in the recent Go releases that are useful for AoC solutions, let's go get them!