### PR TITLE
asciigrid: add All() to iterate over all positions and bytes.

### DIFF
--- a/asciigrid/asciigrid.go
+++ b/asciigrid/asciigrid.go
@@ -5,6 +5,7 @@ package asciigrid
 import (
 	"bytes"
 	"fmt"
+	"iter"
 	"strconv"
 )
 
@@ -324,6 +325,21 @@ func (g *Grid) InBounds(p Pos) bool {
 // represents.
 func (g *Grid) String() string {
 	return string(bytes.Join(g.rows, []byte{'\n'}))
+}
+
+// All iterates over all positions and the byte stored at them, in an undefined
+// order.
+func (g *Grid) All() iter.Seq2[Pos, byte] {
+	return func(yield func(Pos, byte) bool) {
+		for row := 0; row < g.NRows(); row++ {
+			for col := 0; col < g.NCols(); col++ {
+				p := Pos{Row: row, Col: col}
+				if !yield(p, g.Get(p)) {
+					return
+				}
+			}
+		}
+	}
 }
 
 // Iter represents an iterator over bytes in a string. It is intended to be very

--- a/asciigrid/asciigrid_test.go
+++ b/asciigrid/asciigrid_test.go
@@ -245,3 +245,26 @@ ghi
 		}
 	}
 }
+
+func TestGrid_All(t *testing.T) {
+	s := strings.TrimSpace(`
+abcde
+12345
+!@#$%
+`)
+	g := newT(t, s)
+	wantBytes := []byte("abcde12345!@#$%")
+	var gotBytes []byte
+	for p, b := range g.All() {
+		if !g.InBounds(p) {
+			t.Errorf("%v is not in bounds of grid:\n%v", p, g)
+		}
+		if got, want := g.Get(p), b; got != want {
+			t.Errorf("g.Get(%v) = %v; want %v; grid:\n%v", p, got, want, g)
+		}
+		gotBytes = append(gotBytes, b)
+	}
+	if diff := cmp.Diff(wantBytes, gotBytes, cmpopts.SortSlices(func(a, b byte) bool { return a < b })); diff != "" {
+		t.Errorf("Collecting all bytes gave an unexpected result (-want +got)\n%v", diff)
+	}
+}


### PR DESCRIPTION
This is something I need to do relatively frequently, and with the new iterators that were added in Go 1.23, it's much easier to do in an efficient manner.