### PR TITLE
year2024/day02: optimization: avoid concatenating slices.

### DIFF
--- a/year2024/day02/day02.go
+++ b/year2024/day02/day02.go
@@ -9,32 +9,119 @@ import (
 	"go.saser.se/adventofgo/striter"
 )
 
-func isSafeDecreasing(report []int, skipped bool) bool {
+func isSafeIncreasing(report []int) bool {
 	for i := range len(report) - 1 {
-		d := report[i] - report[i+1]
+		d := report[i+1] - report[i]
 		if 1 <= d && d <= 3 {
 			continue
 		}
-		if !skipped {
-			// Skip either the current and the next element, and then check
-			// again, setting the skipped flag to true.
-			var beforeCurrent []int
-			if i > 0 {
-				beforeCurrent = report[i-1 : i]
-			}
-			afterCurrent := report[i+1:]
-			if isSafeDecreasing(slices.Concat(beforeCurrent, afterCurrent), true) {
-				return true
-			}
-			beforeNext := report[i : i+1]
-			var afterNext []int
-			if i < len(report)-2 {
-				afterNext = report[i+2:]
-			}
-			return isSafeDecreasing(slices.Concat(beforeNext, afterNext), true)
-		}
 		return false
 	}
+	return true
+}
+
+func isSafeIncreasingWithSkip(report []int) bool {
+	// Any slice of length 0, 1, or 2 can always be
+	// considered safe.
+	n := len(report)
+	if n <= 2 {
+		return true
+	}
+	for i := range n - 1 {
+		x := report[i]
+		y := report[i+1]
+		if d := y - x; 1 <= d && d <= 3 {
+			continue
+		}
+		// Skip either the current element or the next element. The skip is
+		// implemented by swapping elements around in the slice, so that we can
+		// always take a subslice and call [isSafeIncreasing] on it. This should
+		// (in theory) be more efficient than creating new slices, which will
+		// allocate and copy elements on the heap.
+		//
+		// We have to be careful to restore the order after swapping, since
+		// we're mutating the input argument.
+		if i == 0 {
+			// The slice looks like this:
+			//     [x, y, ...]
+			// First try skipping x.
+			//     initial state: [x, y, ...]
+			//     check [1:]:       [y, ...]
+			if isSafeIncreasing(report[1:]) {
+				return true
+			}
+			// If that doesn't work, try skipping y:
+			//     initial state: [x, y, ...]
+			//     swap x and y:  [y, x, ...]
+			report[i], report[i+1] = report[i+1], report[i]
+			//     check [1:]:       [x, ...]
+			ok := isSafeIncreasing(report[1:])
+			//     swap x and y:  [x, y, ...]
+			report[i], report[i+1] = report[i+1], report[i]
+			if ok {
+				return true
+			}
+			// Neither skipping x or y helped; this report is not safe.
+			return false
+		}
+		if i == len(report)-2 {
+			// The slice looks like this:
+			//     [..., x, y]
+			// First try skipping x.
+			//     initial state: [..., x, y]
+			//     swap x and y:  [..., y, x]
+			report[i], report[i+1] = report[i+1], report[i]
+			//     check [:n-2]:  [..., y]
+			ok := isSafeIncreasing(report[:n-2])
+			//     swap x and y:  [..., x, y]
+			report[i], report[i+1] = report[i+1], report[i]
+			if ok {
+				return true
+			}
+			// If that doesn't work, try skipping y:
+			//     initial state: [..., x, y]
+			//     check [:n-2]:  [..., x]
+			ok = isSafeIncreasing(report[:n-2])
+			if ok {
+				return true
+			}
+			// Neither skipping x or y helped; this report is not safe.
+			return false
+		}
+		// The slice looks like this:
+		//     [..., w, x, y, z, ...]
+		// Since we iterate from the left to the right, we know that the report
+		// [..., w, x] is safe. Therefore, we don't need to check anything
+		// before w again; we only need to check from w and forward.
+		//
+		// First try skipping x.
+		//                             i
+		//     initial state: [..., w, x, y, z, ...]
+		//     swap w and x:  [..., x, w, y, z, ...]
+		report[i-1], report[i] = report[i], report[i-1]
+		//     check from w:          [w, y, z, ...]
+		ok := isSafeIncreasing(report[i:])
+		//     swap w and x:  [..., w, x, y, z, ...]
+		report[i-1], report[i] = report[i], report[i-1]
+		if ok {
+			return true
+		}
+		// If that doesn't work, try skipping y.
+		//                             i
+		//     initial state: [..., w, x, y, z, ...]
+		//     swap x and y:  [..., w, y, x, z, ...]
+		report[i], report[i+1] = report[i+1], report[i]
+		// check from x:                 [x, z, ...]
+		ok = isSafeIncreasing(report[i+1:])
+		//     swap x and y:  [..., w, x, y, z, ...]
+		report[i], report[i+1] = report[i+1], report[i]
+		if ok {
+			return true
+		}
+		// Neither skipping x or y helped; this report is not safe.
+		return false
+	}
+	// The report is safe without skipping anything.
 	return true
 }
 
@@ -51,17 +138,19 @@ func solve(input string, part int) (string, error) {
 				return "", fmt.Errorf("parse integer from line %q: %w", line, err)
 			}
 		}
-		skipped := true
-		if part == 2 {
-			skipped = false
+		var isSafe func(report []int) bool
+		if part == 1 {
+			isSafe = isSafeIncreasing
+		} else {
+			isSafe = isSafeIncreasingWithSkip
 		}
 		// Try both directions, if necessary.
-		if isSafeDecreasing(report, skipped) {
+		if isSafe(report) {
 			count++
 			continue
 		}
 		slices.Reverse(report)
-		if isSafeDecreasing(report, skipped) {
+		if isSafe(report) {
 			count++
 			continue
 		}


### PR DESCRIPTION
The previous solution made us of `slices.Concat` to synthesize new reports where one element was skipped. The downside of that is that `slices.Concat` creates new slices every single time, meaning that memory is allocated on the heap and then elements are copied over.

To avoid those allocations, we can implement the skipping of elements by swapping elements around in-place. The improved algorithm is described through comments in the source code, but the runtime improvements are quite substantial. On my laptop:

    $ go test -bench=. -benchmem -count=10 ./year2024/day02 | tee base.txt  # baseline
    $ go test -bench=. -benchmem -count=10 ./year2024/day02 | tee opt.txt   # with optimizations
    $ benchstat base.txt opt.txt
    goos: linux
    goarch: amd64
    pkg: go.saser.se/adventofgo/year2024/day02
    cpu: AMD Ryzen 9 5900HX with Radeon Graphics
    	 │  base.txt   │               opt.txt               │
    	 │   sec/op    │   sec/op     vs base                │
    Part1-16   171.2µ ± 1%   173.2µ ± 1%   +1.15% (p=0.009 n=10)
    Part2-16   332.2µ ± 1%   185.6µ ± 1%  -44.15% (p=0.000 n=10)
    geomean    238.5µ        179.3µ       -24.84%
    
    	 │   base.txt   │               opt.txt                │
    	 │     B/op     │     B/op      vs base                │
    Part1-16   156.8Ki ± 0%   156.8Ki ± 0%        ~ (p=0.487 n=10)
    Part2-16   298.8Ki ± 0%   156.8Ki ± 0%  -47.51% (p=0.000 n=10)
    geomean    216.5Ki        156.8Ki       -27.55%
    
    	 │  base.txt   │                opt.txt                │
    	 │  allocs/op  │  allocs/op   vs base                  │
    Part1-16   2.001k ± 0%   2.001k ± 0%        ~ (p=1.000 n=10) ¹
    Part2-16   5.169k ± 0%   2.002k ± 0%  -61.27% (p=0.000 n=10)
    geomean    3.216k        2.001k       -37.77%
    ¹ all samples are equal